### PR TITLE
Add item and location name groups

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -8,7 +8,7 @@ from . import rules
 from .bundles.bundle_room import BundleRoom
 from .bundles.bundles import get_all_bundles
 from .items import item_table, create_items, ItemData, Group, items_by_group, get_all_filler_items, remove_limited_amount_packs
-from .locations import location_table, create_locations, LocationData
+from .locations import location_table, create_locations, LocationData, locations_by_tag
 from .logic.bundle_logic import BundleLogic
 from .logic.logic import StardewLogic
 from .logic.time_logic import MAX_MONTHS
@@ -63,6 +63,12 @@ class StardewValleyWorld(World):
 
     item_name_to_id = {name: data.code for name, data in item_table.items()}
     location_name_to_id = {name: data.code for name, data in location_table.items()}
+
+    item_name_groups = {group.name.replace("_", " ").title() + (" Group" if group.name.replace("_", " ").title()
+                                                                in item_table else ""):
+                        [item.name for item in items] for group, items in items_by_group.items()}
+    location_name_groups = {group.name.replace("_", " ").title(): [item.name for item in locations]
+                            for group, locations in locations_by_tag.items()}
 
     data_version = 3
     required_client_version = (0, 4, 0)

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -67,7 +67,7 @@ class StardewValleyWorld(World):
     item_name_groups = {group.name.replace("_", " ").title() + (" Group" if group.name.replace("_", " ").title()
                                                                 in item_table else ""):
                         [item.name for item in items] for group, items in items_by_group.items()}
-    location_name_groups = {group.name.replace("_", " ").title(): [item.name for item in locations]
+    location_name_groups = {group.name.replace("_", " ").title(): [location.name for location in locations]
                             for group, locations in locations_by_tag.items()}
 
     data_version = 3

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -67,9 +67,10 @@ class StardewValleyWorld(World):
     item_name_groups = {group.name.replace("_", " ").title() + (" Group" if group.name.replace("_", " ").title()
                                                                 in item_table else ""):
                         [item.name for item in items] for group, items in items_by_group.items()}
-    location_name_groups = {group.name.replace("_", " ").title(): [location.name for location in locations]
-                            for group, locations in locations_by_tag.items()}
-
+    location_name_groups = {group.name.replace("_", " ").title() + (" Group" if group.name.replace("_", " ").title()
+                                                                    in locations_by_tag else ""):
+                            [location.name for location in locations] for group, locations in locations_by_tag.items()}
+    
     data_version = 3
     required_client_version = (0, 4, 0)
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds item name groups and location name groups using the tags from the CSV. This is of particular interest to me so that I can exclude (or prioritize) categories of locations. I do this often with excluding skills, friendsanity, etc, and it requires a large list. This will allow one to just put `Friendsanity` in `exclude_locations` and it will exclude every friendsanity location, etc.

The code looks a little messy but I wanted to get it all into simple dict comprehension doohickies. Certainly not attached to the methodology, just would like to see the feature.

" Group" is appended to item name group names if they would collide with item names, as this is checked for in a unit test.

## How was this tested?
Running unit tests and generating a game with `Friendsanity` in `exclude_locations`