### PR TITLE
Fix Void Soul GI reqs and naming

### DIFF
--- a/worlds/stardew_valley/data/items.csv
+++ b/worlds/stardew_valley/data/items.csv
@@ -810,7 +810,7 @@ id,name,classification,groups,mod_name
 10501,Marlon's Boat Paddle,progression,GINGER_ISLAND,Stardew Valley Expanded
 10502,Diamond Wand,filler,"WEAPON,DEPRECATED",Stardew Valley Expanded
 10503,Iridium Bomb,progression,,Stardew Valley Expanded
-10504,Krobus' Protection,useful,,Stardew Valley Expanded
+10504,Void Spirit Peace Agreement,useful,GINGER_ISLAND,Stardew Valley Expanded
 10505,Kittyfish Spell,progression,,Stardew Valley Expanded
 10506,Nexus: Adventurer's Guild Runes,progression,MOD_WARP,Stardew Valley Expanded
 10507,Nexus: Junimo Woods Runes,progression,MOD_WARP,Stardew Valley Expanded

--- a/worlds/stardew_valley/data/locations.csv
+++ b/worlds/stardew_valley/data/locations.csv
@@ -2619,7 +2619,7 @@ id,region,name,tags,mod_name
 7509,Grandpa's Shed Interior,Grandpa's Shed,"STORY_QUEST",Stardew Valley Expanded
 7510,Aurora Vineyard,Aurora Vineyard,"STORY_QUEST",Stardew Valley Expanded
 7511,Lance's House Main,Monster Crops,"STORY_QUEST,GINGER_ISLAND",Stardew Valley Expanded
-7512,Sewer,Void Soul Retrieval,"STORY_QUEST",Stardew Valley Expanded
+7512,Sewer,Void Soul Retrieval,"STORY_QUEST,GINGER_ISLAND",Stardew Valley Expanded
 7513,Fairhaven Farm,Andy's Cellar,SPECIAL_ORDER_BOARD,Stardew Valley Expanded
 7514,Adventurer's Guild,A Mysterious Venture,SPECIAL_ORDER_BOARD,Stardew Valley Expanded
 7515,Jenkins' Residence,An Elegant Reception,SPECIAL_ORDER_BOARD,Stardew Valley Expanded

--- a/worlds/stardew_valley/strings/ap_names/mods/mod_items.py
+++ b/worlds/stardew_valley/strings/ap_names/mods/mod_items.py
@@ -16,7 +16,7 @@ class SkillLevel:
 class SVEQuestItem:
     aurora_vineyard_tablet = "Aurora Vineyard Tablet"
     iridium_bomb = "Iridium Bomb"
-    void_soul = "Krobus' Protection"
+    void_soul = "Void Spirit Peace Agreement"
     kittyfish_spell = "Kittyfish Spell"
     scarlett_job_offer = "Scarlett's Job Offer"
     morgan_schooling = "Morgan's Schooling"


### PR DESCRIPTION
And anotha wan

- Add Ginger Island to Void Soul Retrival.
- Add Ginger island to Void Spirits Peace Agreement (renamed from Krobus' Protection as its more accurate).
