### PR TITLE
[Archipela-Go!] add groups for macguffins

### DIFF
--- a/worlds/apgo/__init__.py
+++ b/worlds/apgo/__init__.py
@@ -49,6 +49,11 @@ class APGOWorld(World):
     item_name_to_id = {name: data.id for name, data in item_table.items()}
     location_name_to_id = {name: id for name, id in location_table.items()}
 
+    item_name_groups = {
+        "MacGuffins": set(long_macguffins),
+        "Letters": set(long_macguffins),
+    }
+
     data_version = 0
 
     options_dataclass = APGOOptions


### PR DESCRIPTION
## What is this fixing or adding?
adding item groups MacGuffins and Letters to be able to hint only them, in a sphere-aware way

## How was this tested?
genned a world and connected with the app