### PR TITLE
Er plando

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -35,7 +35,7 @@ from .options.presets import sv_options_presets
 from .options.settings import StardewSettings
 from .options.worlds_group import apply_most_restrictive_options
 from .regions import create_regions, prepare_mod_data
-from .regions.entrance_rando import get_target_groups, prepare_chaos_data
+from .regions.entrance_rando import get_target_groups
 from .rules import set_rules
 from .stardew_rule import HasProgressionPercent, StardewRule, True_
 from .strings.ap_names.ap_option_names import EntranceRandomizationBehaviorOptionName, StartWithoutOptionName
@@ -148,6 +148,7 @@ class StardewValleyWorld(World):
     web = StardewWebWorld()
     modified_bundles: List[BundleRoom]
     randomized_entrances: None | Dict[str, str] = None
+    forced_entrances: dict[str, str]
     trash_bear_requests: Dict[str, List[str]]
 
     total_progression_items: int
@@ -222,7 +223,9 @@ class StardewValleyWorld(World):
         self.modified_bundles = get_all_bundles(self.random, self.logic, self.content, self.options, self.player_name)
         self.trash_bear_requests = get_trash_bear_requests(self.random, self.content, self.options)
         if self.options.entrance_randomization_behavior.is_chaos():
-            self.randomized_entrances = prepare_chaos_data(randomized_connections)
+            self.randomized_entrances = randomized_connections
+        else:
+            self.forced_entrances = randomized_connections
 
         for bundle_room in self.modified_bundles:
             bundle_room.special_behavior(self)
@@ -508,7 +511,7 @@ class StardewValleyWorld(World):
                 target_group_lookup=target_groups,
                 on_connect=connect_cutscene_regions_as_well,
             )
-            self.randomized_entrances = prepare_mod_data(placement)
+            self.randomized_entrances = prepare_mod_data(placement, self.forced_entrances)
         elif not is_chaos:
             # randomized_entrances were in the slot_data, connecting them as entered
             entrances = {entrance.name: entrance for region in self.get_regions() for entrance in region.entrances if entrance.parent_region is None}

--- a/worlds/stardew_valley/options/forced_options.py
+++ b/worlds/stardew_valley/options/forced_options.py
@@ -1,3 +1,4 @@
+from worlds.stardew_valley.regions.model import reverse_connection_name
 import logging
 
 import Options as ap_options
@@ -33,7 +34,7 @@ def force_change_options_if_banned(world_options: options.StardewValleyOptions, 
         message = f"Max Bundles Price {message_template} Replaced with 'Very Expensive'"
         logger.warning(message)
     if (not settings.allow_chaos_er and EntranceRandomizationBehaviorOptionName.chaos in world_options.entrance_randomization_behavior):
-        world_options.entrance_randomization_behavior.value.remove(EntranceRandomizerBehaviourOptionName.chaos)
+        world_options.entrance_randomization_behavior.value.remove(EntranceRandomizationBehaviorOptionName.chaos)
         message = f"Chaos Entrance Randomization {message_template} removed from Entrance Randomization Behaviour"
         logger.warning(message)
     if not settings.allow_shipsanity_everything and world_options.shipsanity == options.Shipsanity.option_everything:
@@ -76,6 +77,7 @@ def force_change_options_if_incompatible(world_options: options.StardewValleyOpt
     force_walnutsanity_deactivation_when_ginger_island_is_excluded(world_options, player, player_name)
     force_qi_special_orders_deactivation_when_ginger_island_is_excluded(world_options, player, player_name)
     force_accessibility_to_full_when_goal_requires_all_locations(player, player_name, world_options)
+    force_reverse_entrance_plando_when_not_decoupled(world_options, player, player_name)
 
 
 def force_no_jojapocalypse_without_being_sure(world_options: options.StardewValleyOptions, player: int, player_name: str) -> None:
@@ -169,6 +171,23 @@ def force_qi_special_orders_deactivation_when_ginger_island_is_excluded(world_op
         world_options.special_order_locations.value -= options.SpecialOrderLocations.value_qi
         logger.warning(f"Mr. Qi's Special Orders requires Ginger Island. "
                        f"Ginger Island was excluded from {player} ({player_name})'s world, so Special Order Locations was changed from {original_option_name} to {world_options.special_order_locations.current_option_name}")
+
+
+def force_reverse_entrance_plando_when_not_decoupled(world_options: options.StardewValleyOptions, player, player_name):
+    if EntranceRandomizationBehaviorOptionName.decoupled in world_options.entrance_randomization_behavior:
+        return
+    plando_map = world_options.entrance_randomization_plando.value
+    to_add = {}
+    for before, after in plando_map.items():
+        after_rev = reverse_connection_name(after)
+        before_rev = reverse_connection_name(before)
+        if after_rev in plando_map:
+            continue
+        if after_rev is None and before_rev is None:  # a one-way
+            continue
+        logger.warning(f"Adding forced connection '{after_rev}: {before_rev}' due to '{before}: {after}' existing for player {player} ({player_name})")
+        to_add[after_rev] = before_rev
+    world_options.entrance_randomization_plando.value.update(to_add)
 
 
 def force_accessibility_to_full_when_goal_requires_all_locations(player, player_name, world_options):

--- a/worlds/stardew_valley/options/forced_options.py
+++ b/worlds/stardew_valley/options/forced_options.py
@@ -176,7 +176,7 @@ def force_qi_special_orders_deactivation_when_ginger_island_is_excluded(world_op
 def force_reverse_entrance_plando_when_not_decoupled(world_options: options.StardewValleyOptions, player, player_name):
     if EntranceRandomizationBehaviorOptionName.decoupled in world_options.entrance_randomization_behavior:
         return
-    plando_map = world_options.entrance_randomization_plando.value
+    plando_map = world_options.entrance_plando.value
     to_add = {}
     for before, after in plando_map.items():
         after_rev = reverse_connection_name(after)
@@ -187,7 +187,7 @@ def force_reverse_entrance_plando_when_not_decoupled(world_options: options.Star
             continue
         logger.warning(f"Adding forced connection '{after_rev}: {before_rev}' due to '{before}: {after}' existing for player {player} ({player_name})")
         to_add[after_rev] = before_rev
-    world_options.entrance_randomization_plando.value.update(to_add)
+    world_options.entrance_plando.value.update(to_add)
 
 
 def force_accessibility_to_full_when_goal_requires_all_locations(player, player_name, world_options):

--- a/worlds/stardew_valley/options/option_groups.py
+++ b/worlds/stardew_valley/options/option_groups.py
@@ -79,7 +79,7 @@ else:
             options.BundleWhitelist,
             options.BundleBlacklist,
             options.CustomLogic,
-            options.EntranceRandomizationPlando,
+            options.EntrancePlando,
             ap_options.ProgressionBalancing,
             ap_options.Accessibility,
         ]),

--- a/worlds/stardew_valley/options/option_groups.py
+++ b/worlds/stardew_valley/options/option_groups.py
@@ -81,6 +81,7 @@ else:
             options.CustomLogic,
             ap_options.ProgressionBalancing,
             ap_options.Accessibility,
+            options.EntranceRandomizationPlando
         ]),
         OptionGroup("Jojapocalypse", [
             options.Jojapocalypse,

--- a/worlds/stardew_valley/options/option_groups.py
+++ b/worlds/stardew_valley/options/option_groups.py
@@ -79,9 +79,9 @@ else:
             options.BundleWhitelist,
             options.BundleBlacklist,
             options.CustomLogic,
+            options.EntranceRandomizationPlando
             ap_options.ProgressionBalancing,
             ap_options.Accessibility,
-            options.EntranceRandomizationPlando
         ]),
         OptionGroup("Jojapocalypse", [
             options.Jojapocalypse,

--- a/worlds/stardew_valley/options/option_groups.py
+++ b/worlds/stardew_valley/options/option_groups.py
@@ -79,7 +79,7 @@ else:
             options.BundleWhitelist,
             options.BundleBlacklist,
             options.CustomLogic,
-            options.EntranceRandomizationPlando
+            options.EntranceRandomizationPlando,
             ap_options.ProgressionBalancing,
             ap_options.Accessibility,
         ]),

--- a/worlds/stardew_valley/options/options.py
+++ b/worlds/stardew_valley/options/options.py
@@ -253,7 +253,7 @@ class EntranceRandomizationBehavior(OptionSet):
         return EntranceRandomizationBehaviorOptionName.chaos in self.value
 
 
-class EntranceRandomizationPlando(OptionDict):
+class EntrancePlando(OptionDict):
     """Set where specific Entrances go instead of being randomized.
     Should have entries of the format
     `Farm to Forest: Forest to Town`
@@ -262,7 +262,7 @@ class EntranceRandomizationPlando(OptionDict):
     in the example Forest to Farm would also get randomized even if it wasn't before to negate failures.
     """
     default = {}
-    internal_name = "entrance_randomization_plando"
+    internal_name = "entrance_plando"
     display_name = "Entrance Plando"
 
 
@@ -1272,8 +1272,8 @@ class StardewValleyOptions(PerGameCommonOptions):
     bundle_price: BundlePrice
     bundle_per_room: BundlePerRoom
     entrance_randomization: EntranceRandomization
-    entrance_randomization_plando: EntranceRandomizationPlando
     entrance_randomization_behavior: EntranceRandomizationBehavior
+    entrance_plando: EntrancePlando
     start_without: StartWithout
     season_randomization: SeasonRandomization
     cropsanity: Cropsanity

--- a/worlds/stardew_valley/options/options.py
+++ b/worlds/stardew_valley/options/options.py
@@ -258,7 +258,8 @@ class EntranceRandomizationPlando(OptionDict):
     Should have entries of the format
     `Farm to Forest: Forest to Town`
     which will make leaving the farm leads to the town from the left bottom.
-    Note that this only works for entrances that are randomized by Entrance Randomization
+    Note that this even works for entrances that are not randomized by Entrance Randomization,
+    in the example Forest to Farm would also get randomized even if it wasn't before to negate failures.
     """
     default = {}
     internal_name = "entrance_randomization_plando"

--- a/worlds/stardew_valley/options/options.py
+++ b/worlds/stardew_valley/options/options.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Protocol, ClassVar
 
 from Options import Range, NamedRange, Toggle, Choice, OptionSet, PerGameCommonOptions, DeathLink, OptionList, \
-    Visibility, Removed, OptionCounter
+    Visibility, Removed, OptionCounter, OptionDict
 from .jojapocalypse_options import Jojapocalypse, JojaStartPrice, JojaEndPrice, JojaPricingPattern, JojaPurchasesForMembership, JojaAreYouSure
 from ..mods.mod_data import ModNames, invalid_mod_combinations
 from ..strings.ap_names.ap_option_names import BuffOptionName, WalnutsanityOptionName, SecretsanityOptionName, EatsanityOptionName, ChefsanityOptionName, \
@@ -219,6 +219,16 @@ class EntranceRandomization(Choice):
 
     def randomized_fast_travel_warps(self) -> bool:
         return self.value >= self.option_everywhere
+
+
+class EntranceRandomizationPlando(OptionDict):
+    """Lock certain Entrances that would otherwise be randomized.
+    Should have entries of the format
+    `Farm to Forest: Forest to Town`
+    which will make leaving the farm leads to the town from the left bottom"""
+    default = {}
+    internal_name = "entrance_randomization_plando"
+    display_name = "Entrance Plando"
 
 
 class EntranceRandomizationBehavior(OptionSet):
@@ -1259,6 +1269,7 @@ class StardewValleyOptions(PerGameCommonOptions):
     bundle_price: BundlePrice
     bundle_per_room: BundlePerRoom
     entrance_randomization: EntranceRandomization
+    entrance_randomization_plando: EntranceRandomizationPlando
     entrance_randomization_behavior: EntranceRandomizationBehavior
     start_without: StartWithout
     season_randomization: SeasonRandomization

--- a/worlds/stardew_valley/options/options.py
+++ b/worlds/stardew_valley/options/options.py
@@ -265,6 +265,8 @@ class EntrancePlando(OptionDict):
     internal_name = "entrance_plando"
     display_name = "Entrance Plando"
 
+    visibility = Visibility.all & ~Visibility.simple_ui
+
 
 class StartWithout(OptionSet):
     """ Items that, in vanilla, you generally start with (or get very quickly), but in Archipelago, you would rather start without them.

--- a/worlds/stardew_valley/options/options.py
+++ b/worlds/stardew_valley/options/options.py
@@ -221,16 +221,6 @@ class EntranceRandomization(Choice):
         return self.value >= self.option_everywhere
 
 
-class EntranceRandomizationPlando(OptionDict):
-    """Lock certain Entrances that would otherwise be randomized.
-    Should have entries of the format
-    `Farm to Forest: Forest to Town`
-    which will make leaving the farm leads to the town from the left bottom"""
-    default = {}
-    internal_name = "entrance_randomization_plando"
-    display_name = "Entrance Plando"
-
-
 class EntranceRandomizationBehavior(OptionSet):
     """Modifications to how ER will behave within the randomized locations.
     - Chaos: all Enabled entrances are reshuffled every day!
@@ -261,6 +251,18 @@ class EntranceRandomizationBehavior(OptionSet):
 
     def is_chaos(self) -> bool:
         return EntranceRandomizationBehaviorOptionName.chaos in self.value
+
+
+class EntranceRandomizationPlando(OptionDict):
+    """Set where specific Entrances go instead of being randomized.
+    Should have entries of the format
+    `Farm to Forest: Forest to Town`
+    which will make leaving the farm leads to the town from the left bottom.
+    Note that this only works for entrances that are randomized by Entrance Randomization
+    """
+    default = {}
+    internal_name = "entrance_randomization_plando"
+    display_name = "Entrance Plando"
 
 
 class StartWithout(OptionSet):

--- a/worlds/stardew_valley/regions/entrance_rando.py
+++ b/worlds/stardew_valley/regions/entrance_rando.py
@@ -8,20 +8,8 @@ from ..strings.ap_names.ap_option_names import EntranceRandomizationBehaviorOpti
 from .model import ConnectionData, GroupFlag, RandomizationFlag, RegionData, reverse_connection_name
 
 
-def create_player_randomization_flag(
-        entrance_randomization_choice: EntranceRandomization,
-        entrance_behavior_choice: set[EntranceRandomizationBehaviorOptionName],
-        include_endgame: bool,
-        content: StardewContent,
-):
-    """Return the flag that a connection is expected to have to be randomized. Only the bit corresponding to the player randomization choice will be enabled.
-
-    Other bits for content exclusion might also be enabled, tho the preferred solution to exclude content should be to not create those regions at alls, when possible.
-    """
+def create_base_randomization_flag(entrance_randomization_choice: EntranceRandomization) -> RandomizationFlag:
     flag = RandomizationFlag.NOT_RANDOMIZED
-
-    if entrance_randomization_choice.value == EntranceRandomization.option_disabled:
-        return flag
 
     if entrance_randomization_choice == EntranceRandomization.option_pelican_town:
         flag |= RandomizationFlag.SET_PELICAN_TOWN
@@ -34,8 +22,28 @@ def create_player_randomization_flag(
     elif entrance_randomization_choice == EntranceRandomization.option_everywhere:
         flag |= RandomizationFlag.SET_EVERYTHING
 
-    if (EntranceRandomizationBehaviorOptionName.shuffle_farmhouse in entrance_behavior_choice
-            or EntranceRandomizationBehaviorOptionName.shuffle_farmhouse_anywhere in entrance_behavior_choice):
+    return flag
+
+
+def create_player_randomization_flag(
+        entrance_randomization_choice: EntranceRandomization,
+        entrance_behavior_choice: set[EntranceRandomizationBehaviorOptionName],
+        include_endgame: bool,
+        content: StardewContent,
+):
+    """Return the flag that a connection is expected to have to be randomized. Only the bit corresponding to the player randomization choice will be enabled.
+
+    Other bits for content exclusion might also be enabled, tho the preferred solution to exclude content should be to not create those regions at alls, when possible.
+    """
+    if entrance_randomization_choice.value == EntranceRandomization.option_disabled:
+        return RandomizationFlag.NOT_RANDOMIZED
+
+    flag = create_base_randomization_flag(entrance_randomization_choice)
+
+    if (
+            EntranceRandomizationBehaviorOptionName.shuffle_farmhouse in entrance_behavior_choice
+            or EntranceRandomizationBehaviorOptionName.shuffle_farmhouse_anywhere in entrance_behavior_choice
+    ):
         flag |= RandomizationFlag.FARMHOUSE
     if content.features.skill_progression.are_masteries_shuffled:
         flag |= RandomizationFlag.MASTERY_CAVE
@@ -51,14 +59,22 @@ def get_target_groups(entrance_randomization_behavior: EntranceRandomizationBeha
         GroupFlag.DOWN: [GroupFlag.UP, GroupFlag.DOOR, GroupFlag.TO_ANY],
         GroupFlag.LEFT: [GroupFlag.RIGHT, GroupFlag.TO_ANY],
         GroupFlag.RIGHT: [GroupFlag.LEFT, GroupFlag.TO_ANY],
-        GroupFlag.DOOR: [GroupFlag.DOWN, GroupFlag.TO_ANY]}
+        GroupFlag.DOOR: [GroupFlag.DOWN, GroupFlag.TO_ANY],
+    }
 
     area_matching_group_lookup = {
-        GroupFlag.TO_ANY: [GroupFlag.IN_TO_IN, GroupFlag.IN_TO_OUT, GroupFlag.OUT_TO_IN, GroupFlag.OUT_TO_OUT, GroupFlag.TO_ANY],
+        GroupFlag.TO_ANY: [
+            GroupFlag.IN_TO_IN,
+            GroupFlag.IN_TO_OUT,
+            GroupFlag.OUT_TO_IN,
+            GroupFlag.OUT_TO_OUT,
+            GroupFlag.TO_ANY,
+        ],
         GroupFlag.IN_TO_IN: [GroupFlag.IN_TO_IN, GroupFlag.TO_ANY],
         GroupFlag.IN_TO_OUT: [GroupFlag.IN_TO_OUT, GroupFlag.TO_ANY],
         GroupFlag.OUT_TO_IN: [GroupFlag.OUT_TO_IN, GroupFlag.TO_ANY],
-        GroupFlag.OUT_TO_OUT: [GroupFlag.OUT_TO_OUT, GroupFlag.TO_ANY]}
+        GroupFlag.OUT_TO_OUT: [GroupFlag.OUT_TO_OUT, GroupFlag.TO_ANY],
+    }
 
     dir_mask = 0b0
     area_mask = 0b0
@@ -72,26 +88,35 @@ def get_target_groups(entrance_randomization_behavior: EntranceRandomizationBeha
 
     groups = {
         int(direction | inorout): [
-            int(pair_direction | pair_inorout) for pair_direction in direction_matching_group_lookup[direction & dir_mask]
-            for pair_inorout in area_matching_group_lookup[inorout & area_mask]]
+            int(pair_direction | pair_inorout)
+            for pair_direction in direction_matching_group_lookup[direction & dir_mask]
+            for pair_inorout in area_matching_group_lookup[inorout & area_mask]
+        ]
         for direction in [
             GroupFlag.TO_ANY,
             GroupFlag.UP,
             GroupFlag.DOWN,
             GroupFlag.LEFT,
             GroupFlag.RIGHT,
-            GroupFlag.DOOR, ]
+            GroupFlag.DOOR,
+        ]
         for inorout in [
             GroupFlag.TO_ANY,
             GroupFlag.IN_TO_IN,
             GroupFlag.IN_TO_OUT,
             GroupFlag.OUT_TO_IN,
-            GroupFlag.OUT_TO_OUT, ]}
+            GroupFlag.OUT_TO_OUT,
+        ]
+    }
 
     groups[int(GroupFlag.DOWN | GroupFlag.IN_TO_OUT | GroupFlag.FROM_FARMHOUSE)] = [
-        int(pair_direction | pair_inorout | farmhouse_flag) for pair_direction in direction_matching_group_lookup[GroupFlag.DOWN & dir_mask]
-        for pair_inorout in (area_matching_group_lookup[GroupFlag.IN_TO_OUT] + area_matching_group_lookup[GroupFlag.OUT_TO_OUT]) for farmhouse_flag in
-        [GroupFlag.FROM_FARMHOUSE, GroupFlag.TO_ANY]]
+        int(pair_direction | pair_inorout | farmhouse_flag)
+        for pair_direction in direction_matching_group_lookup[GroupFlag.DOWN & dir_mask]
+        for pair_inorout in (
+                area_matching_group_lookup[GroupFlag.IN_TO_OUT] + area_matching_group_lookup[GroupFlag.OUT_TO_OUT]
+        )
+        for farmhouse_flag in [GroupFlag.FROM_FARMHOUSE, GroupFlag.TO_ANY]
+    ]
     return groups
 
 
@@ -115,13 +140,13 @@ def connect_regions(
             if eligible and is_chaos:
                 special_randomized_entrances[connection_data.name] = connection_data.name
                 origin_region.connect(destination_region, connection_data.name)
-            elif eligible and connection_data.name in er_plando:
+            elif connection_data.name in er_plando:
                 new_connection_name = er_plando[connection_data.name]
                 new_connection = connection_data_by_name[new_connection_name]
                 special_randomized_entrances[connection_data.name] = new_connection_name
                 dest = regions_by_name[new_connection.destination]
                 origin_region.connect(dest, connection_data.name)
-            elif eligible:
+            elif eligible or connection_data.reverse in er_plando:
                 create_entrance_rando_target(origin_region, destination_region, connection_data)
             else:
                 origin_region.connect(destination_region, connection_data.name)

--- a/worlds/stardew_valley/regions/entrance_rando.py
+++ b/worlds/stardew_valley/regions/entrance_rando.py
@@ -128,9 +128,7 @@ def connect_regions(
     return special_randomized_entrances
 
 
-def create_entrance_rando_target(
-        origin: Region, destination: Region, connection_data: ConnectionData
-) -> None:
+def create_entrance_rando_target(origin: Region, destination: Region, connection_data: ConnectionData) -> None:
     """We need our own function to create the GER targets, because the Stardew Mod have very specific expectations for the name of the entrances.
     We need to know exactly which entrances to swap in both directions."""
 
@@ -150,9 +148,7 @@ def create_entrance_rando_target(
     origin.create_er_target(connection_data.name).randomization_type = EntranceType.TWO_WAY
 
 
-def prepare_mod_data(
-        placements: ERPlacementState, forced_placements: dict[str, str]
-) -> dict[str, str]:
+def prepare_mod_data(placements: ERPlacementState, forced_placements: dict[str, str]) -> dict[str, str]:
     """Take the placements from GER and prepare the data for the mod.
     The mod require a dictionary detailing which connections need to be swapped. It acts as if the connections are decoupled, so both directions are required.
 

--- a/worlds/stardew_valley/regions/entrance_rando.py
+++ b/worlds/stardew_valley/regions/entrance_rando.py
@@ -100,9 +100,10 @@ def connect_regions(
         connection_data_by_name: dict[str, ConnectionData],
         regions_by_name: dict[str, Region],
         player_randomization_flag: RandomizationFlag,
-        is_chaos: bool
-) -> set[str]:
-    randomized_entrances: set[str] = set()
+        er_plando: dict[str, str],
+        is_chaos: bool,
+) -> dict[str, str]:
+    special_randomized_entrances: dict[str, str] = {}
     for region_name, region_data in region_data_by_name.items():
         origin_region = regions_by_name[region_name]
 
@@ -112,17 +113,24 @@ def connect_regions(
 
             eligible = connection_data.is_eligible_for_randomization(player_randomization_flag)
             if eligible and is_chaos:
-                randomized_entrances.add(connection_data.name)
+                special_randomized_entrances[connection_data.name] = connection_data.name
                 origin_region.connect(destination_region, connection_data.name)
+            elif eligible and connection_data.name in er_plando:
+                new_connection_name = er_plando[connection_data.name]
+                new_connection = connection_data_by_name[new_connection_name]
+                special_randomized_entrances[connection_data.name] = new_connection_name
+                dest = regions_by_name[new_connection.destination]
+                origin_region.connect(dest, connection_data.name)
             elif eligible:
-                randomized_entrances.add(connection_data.name)
                 create_entrance_rando_target(origin_region, destination_region, connection_data)
             else:
                 origin_region.connect(destination_region, connection_data.name)
-    return randomized_entrances
+    return special_randomized_entrances
 
 
-def create_entrance_rando_target(origin: Region, destination: Region, connection_data: ConnectionData) -> None:
+def create_entrance_rando_target(
+        origin: Region, destination: Region, connection_data: ConnectionData
+) -> None:
     """We need our own function to create the GER targets, because the Stardew Mod have very specific expectations for the name of the entrances.
     We need to know exactly which entrances to swap in both directions."""
 
@@ -139,20 +147,12 @@ def create_entrance_rando_target(origin: Region, destination: Region, connection
     exit = origin.create_exit(connection_data.name)
     exit.randomization_type = EntranceType.TWO_WAY
     exit.randomization_group = connection_data.group
-    destination.create_er_target(rev).randomization_type = EntranceType.TWO_WAY
+    origin.create_er_target(connection_data.name).randomization_type = EntranceType.TWO_WAY
 
 
-def prepare_chaos_data(
-        randomized_connections: set[str]
+def prepare_mod_data(
+        placements: ERPlacementState, forced_placements: dict[str, str]
 ) -> dict[str, str]:
-    randomized_entrances: dict[str, str] = {}
-
-    for connection in randomized_connections:
-        randomized_entrances[connection] = connection
-    return randomized_entrances
-
-
-def prepare_mod_data(placements: ERPlacementState) -> dict[str, str]:
     """Take the placements from GER and prepare the data for the mod.
     The mod require a dictionary detailing which connections need to be swapped. It acts as if the connections are decoupled, so both directions are required.
 
@@ -167,4 +167,5 @@ def prepare_mod_data(placements: ERPlacementState) -> dict[str, str]:
     for entrance, exit_ in placements.pairings:
         swapped_connections[entrance] = reverse_connection_name(exit_) or exit_
 
+    swapped_connections.update(forced_placements)
     return swapped_connections

--- a/worlds/stardew_valley/regions/regions.py
+++ b/worlds/stardew_valley/regions/regions.py
@@ -33,7 +33,7 @@ def create_regions(region_factory: RegionFactory, world_options: StardewValleyOp
 
     is_chaos = world_options.entrance_randomization_behavior.is_chaos()
     randomized_entrances = connect_regions(region_data_by_name, connection_data_by_name, regions_by_name, randomization_flag,
-                                           world_options.entrance_randomization_plando.value, is_chaos)
+                                           world_options.entrance_plando.value, is_chaos)
 
     return regions_by_name, randomized_entrances
 

--- a/worlds/stardew_valley/regions/regions.py
+++ b/worlds/stardew_valley/regions/regions.py
@@ -16,7 +16,7 @@ class RegionFactory(Protocol):
         raise NotImplementedError
 
 
-def create_regions(region_factory: RegionFactory, world_options: StardewValleyOptions, content: StardewContent) -> tuple[dict[str, Region], set[str]]:
+def create_regions(region_factory: RegionFactory, world_options: StardewValleyOptions, content: StardewContent) -> tuple[dict[str, Region], dict[str, str]]:
     # the ginger island regions are now a content pack instead of a special case, but this does mean the pack needs to be registerd
     if not world_options.exclude_ginger_island.value:
         content.registered_packs.add(ModNames.ginger_island)
@@ -32,7 +32,8 @@ def create_regions(region_factory: RegionFactory, world_options: StardewValleyOp
                                                           world_options.include_endgame_locations.value, content)
 
     is_chaos = world_options.entrance_randomization_behavior.is_chaos()
-    randomized_entrances = connect_regions(region_data_by_name, connection_data_by_name, regions_by_name, randomization_flag, is_chaos)
+    randomized_entrances = connect_regions(region_data_by_name, connection_data_by_name, regions_by_name, randomization_flag,
+                                           world_options.entrance_randomization_plando.value, is_chaos)
 
     return regions_by_name, randomized_entrances
 

--- a/worlds/stardew_valley/test/bases.py
+++ b/worlds/stardew_valley/test/bases.py
@@ -282,7 +282,7 @@ def should_cache_world(test_options):
     if "start_inventory" in test_options:
         return False
 
-    entrance_plando_key = "entrance_randomization_plando"
+    entrance_plando_key = "entrance_plando"
     entrance_plando = test_options.get(entrance_plando_key, {})
     if len(entrance_plando) > 0:
         return False

--- a/worlds/stardew_valley/test/bases.py
+++ b/worlds/stardew_valley/test/bases.py
@@ -282,6 +282,11 @@ def should_cache_world(test_options):
     if "start_inventory" in test_options:
         return False
 
+    entrance_plando_key = "entrance_randomization_plando"
+    entrance_plando = test_options.get(entrance_plando_key, {})
+    if len(entrance_plando) > 0:
+        return False
+
     trap_distribution_key = "trap_distribution"
     if trap_distribution_key not in test_options:
         return True

--- a/worlds/stardew_valley/test/regions/TestEntrancePlando.py
+++ b/worlds/stardew_valley/test/regions/TestEntrancePlando.py
@@ -1,0 +1,122 @@
+from collections import deque
+from collections.abc import Collection
+from unittest.mock import Mock, patch
+
+from BaseClasses import Entrance, MultiWorld, Region, get_seed
+from worlds.stardew_valley.strings.ap_names.ap_option_names import EntranceRandomizationBehaviorOptionName
+
+from ... import options
+from ...mods.mod_data import ModNames
+from ...options import EntranceRandomization, ExcludeGingerIsland, SkillProgression
+from ...options.options import EntranceRandomizationBehavior, EntranceRandomizationPlando, all_mods
+from ...regions.entrance_rando import connect_regions, create_entrance_rando_target, prepare_mod_data
+from ...regions.model import ConnectionData, RandomizationFlag, RegionData
+from ...strings.entrance_names import Entrance as EntranceName
+from ...strings.region_names import Region as RegionName
+from ..assertion import WorldAssertMixin
+from ..bases import SVTestBase, SVTestCase, setup_solo_multiworld, solo_multiworld
+
+
+class TestEntrancePlandoCoupled(SVTestBase):
+    options = {
+        EntranceRandomization: EntranceRandomization.option_everywhere,
+        EntranceRandomizationBehavior: {},
+        EntranceRandomizationPlando: {
+            EntranceName.farmhouse_to_farm: EntranceName.town_to_beach,
+            EntranceName.farm_to_backwoods: EntranceName.mountain_to_railroad,
+            EntranceName.farm_to_forest: EntranceName.enter_secret_woods,
+        },
+        ExcludeGingerIsland: ExcludeGingerIsland.option_false,
+    }
+
+    def test_plando_of_randomized_entrances(self):
+        for plando in [
+            (EntranceName.farm_to_backwoods, RegionName.farm, RegionName.railroad),
+            (EntranceName.farm_to_forest, RegionName.farm, RegionName.secret_woods),
+            # reverse connections should be created as well
+            (EntranceName.railroad_to_mountain, RegionName.railroad, RegionName.farm),
+            (EntranceName.leave_secret_woods, RegionName.secret_woods, RegionName.farm),
+        ]:
+            entrance_name, begin, end = plando
+            with self.subTest(f"{entrance_name} goes from {begin} to {end}"):
+                entrance = self.world.get_entrance(entrance_name)
+                entrance_region = self.world.get_region(begin)
+                target_region = self.world.get_region(end)
+
+                self.assertEqual(entrance.parent_region, entrance_region)
+                self.assertEqual(entrance.connected_region, target_region)
+
+    def test_plando_of_non_randomized_still_happens(self):
+        farmhouse_region = self.world.get_region(RegionName.farm_house)
+        beach_region = self.world.get_region(RegionName.beach)
+
+        with self.subTest(f"Testing plandoed connection"):
+            entrance = self.world.get_entrance(EntranceName.farmhouse_to_farm)
+            self.assertEqual(entrance.parent_region, farmhouse_region)
+            self.assertEqual(entrance.connected_region, beach_region)
+
+        with self.subTest(f"Testing reversed connection"):
+            rev_entrance = self.world.get_entrance(EntranceName.beach_to_town)
+            self.assertEqual(rev_entrance.parent_region, beach_region)
+            self.assertEqual(rev_entrance.connected_region, farmhouse_region)
+
+    def test_only_plando_in_placement_info(self):
+        # DOES include the reverse connections if not plandoed
+        self.assertDictEqual(
+            {
+                EntranceName.farm_to_backwoods: EntranceName.mountain_to_railroad,
+                EntranceName.railroad_to_mountain: EntranceName.backwoods_to_farm,
+                EntranceName.farm_to_forest: EntranceName.enter_secret_woods,
+                EntranceName.leave_secret_woods: EntranceName.forest_to_farm,
+                EntranceName.farmhouse_to_farm: EntranceName.town_to_beach,
+                EntranceName.beach_to_town: EntranceName.farm_to_farmhouse,
+            },
+            self.world.forced_entrances,
+        )
+
+
+class TestEntrancePlandoDecoupled(SVTestBase):
+    options = {
+        EntranceRandomization: EntranceRandomization.option_everywhere,
+        EntranceRandomizationBehavior: {EntranceRandomizationBehaviorOptionName.decoupled},
+        EntranceRandomizationPlando: {
+            EntranceName.farmhouse_to_farm: EntranceName.town_to_beach,
+            EntranceName.farm_to_backwoods: EntranceName.mountain_to_railroad,
+            EntranceName.farm_to_forest: EntranceName.enter_secret_woods,
+        },
+        ExcludeGingerIsland: ExcludeGingerIsland.option_false,
+    }
+
+    def test_plando_of_randomized_entrances(self):
+        for plando in [
+            (EntranceName.farm_to_backwoods, RegionName.farm, RegionName.railroad),
+            (EntranceName.farm_to_forest, RegionName.farm, RegionName.secret_woods),
+        ]:
+            entrance_name, begin, end = plando
+            with self.subTest(f"{entrance_name} goes from {begin} to {end}"):
+                entrance = self.world.get_entrance(entrance_name)
+                entrance_region = self.world.get_region(begin)
+                target_region = self.world.get_region(end)
+
+                self.assertEqual(entrance.parent_region, entrance_region)
+                self.assertEqual(entrance.connected_region, target_region)
+
+    def test_plando_of_non_randomized_still_happens(self):
+        farmhouse_region = self.world.get_region(RegionName.farm_house)
+        beach_region = self.world.get_region(RegionName.beach)
+
+        with self.subTest(f"Testing plandoed connection"):
+            entrance = self.world.get_entrance(EntranceName.farmhouse_to_farm)
+            self.assertEqual(entrance.parent_region, farmhouse_region)
+            self.assertEqual(entrance.connected_region, beach_region)
+
+    def test_only_plando_in_placement_info(self):
+        # DOES NOT include the reverse connections if not plandoed
+        self.assertDictEqual(
+            {
+                EntranceName.farm_to_backwoods: EntranceName.mountain_to_railroad,
+                EntranceName.farm_to_forest: EntranceName.enter_secret_woods,
+                EntranceName.farmhouse_to_farm: EntranceName.town_to_beach,
+            },
+            self.world.forced_entrances,
+        )

--- a/worlds/stardew_valley/test/regions/TestEntrancePlando.py
+++ b/worlds/stardew_valley/test/regions/TestEntrancePlando.py
@@ -8,7 +8,7 @@ from worlds.stardew_valley.strings.ap_names.ap_option_names import EntranceRando
 from ... import options
 from ...mods.mod_data import ModNames
 from ...options import EntranceRandomization, ExcludeGingerIsland, SkillProgression
-from ...options.options import EntranceRandomizationBehavior, EntranceRandomizationPlando, all_mods
+from ...options.options import EntranceRandomizationBehavior, EntrancePlando, all_mods
 from ...regions.entrance_rando import connect_regions, create_entrance_rando_target, prepare_mod_data
 from ...regions.model import ConnectionData, RandomizationFlag, RegionData
 from ...strings.entrance_names import Entrance as EntranceName
@@ -21,7 +21,7 @@ class TestEntrancePlandoCoupled(SVTestBase):
     options = {
         EntranceRandomization: EntranceRandomization.option_everywhere,
         EntranceRandomizationBehavior: {},
-        EntranceRandomizationPlando: {
+        EntrancePlando: {
             EntranceName.farmhouse_to_farm: EntranceName.town_to_beach,
             EntranceName.farm_to_backwoods: EntranceName.mountain_to_railroad,
             EntranceName.farm_to_forest: EntranceName.enter_secret_woods,
@@ -79,7 +79,7 @@ class TestEntrancePlandoDecoupled(SVTestBase):
     options = {
         EntranceRandomization: EntranceRandomization.option_everywhere,
         EntranceRandomizationBehavior: {EntranceRandomizationBehaviorOptionName.decoupled},
-        EntranceRandomizationPlando: {
+        EntrancePlando: {
             EntranceName.farmhouse_to_farm: EntranceName.town_to_beach,
             EntranceName.farm_to_backwoods: EntranceName.mountain_to_railroad,
             EntranceName.farm_to_forest: EntranceName.enter_secret_woods,

--- a/worlds/stardew_valley/test/regions/TestEntranceRandomization.py
+++ b/worlds/stardew_valley/test/regions/TestEntranceRandomization.py
@@ -35,27 +35,31 @@ class TestEntranceRando(SVTestCase):
         player_randomization_flag = RandomizationFlag.SET_PELICAN_TOWN
 
         with patch("worlds.stardew_valley.regions.entrance_rando.create_entrance_rando_target") as mock_create_entrance_rando_target:
-            connect_regions(region_data_by_name, connection_data_by_name, regions_by_name, player_randomization_flag, False)
+            connect_regions(region_data_by_name, connection_data_by_name, regions_by_name, player_randomization_flag, {}, False)
 
             expected_origin, expected_destination = regions_by_name["Region1"], regions_by_name["Region2"]
             expected_connection = connection_data_by_name["randomized_connection"]
             mock_create_entrance_rando_target.assert_called_once_with(expected_origin, expected_destination, expected_connection)
 
-    def test_when_create_entrance_rando_target_then_create_exit_and_er_target(self):
+    def test_when_create_entrance_rando_target_both_ways_exits_and_targets_are_correct(self):
         origin = Mock()
         destination = Mock()
         connection_data = ConnectionData("origin to destination", "destination")
+        connection_data_back = ConnectionData("destination to origin", "origin")
 
         create_entrance_rando_target(origin, destination, connection_data)
+        create_entrance_rando_target(destination, origin, connection_data_back)
 
         origin.create_exit.assert_called_once_with("origin to destination")
+        origin.create_er_target.assert_called_once_with("origin to destination")
+        destination.create_exit.assert_called_once_with("destination to origin")
         destination.create_er_target.assert_called_once_with("destination to origin")
 
     def test_when_prepare_mod_data_then_swapped_connections_contains_both_directions(self):
         # all two-way warps are explicit to allow for detached.
         placements = Mock(pairings=[("A to B", "C to A"), ("C to A", "A to B"), ("C to D", "A to C"), ("A to C", "C to D")])
 
-        swapped_connections = prepare_mod_data(placements)
+        swapped_connections = prepare_mod_data(placements, {})
 
         self.assertEqual({"A to B": "A to C", "C to A": "B to A", "C to D": "C to A", "A to C": "D to C"}, swapped_connections)
 


### PR DESCRIPTION
Adds a way to plando specific connections for ER

Important things to note:
- Only entrances that would be randomized anyways are checked
- Chaos ER overrides this plando
- Modifies slot_data in such a way that the mod does not need to change

I still need to test it in game, but from some logging in slot_data it seems to work as expected

Might want to add a setting check for if plando connections are enabled, but didn't have time to search for that yet