### PR TITLE
fix volcano 5 to island north not entrance randomizing

### DIFF
--- a/worlds/stardew_valley/regions/vanilla_content_packs.py
+++ b/worlds/stardew_valley/regions/vanilla_content_packs.py
@@ -406,7 +406,7 @@ ginger_island_connections = [
     ConnectionData(
         Entrance.volcano_5_to_island_north,
         Region.island_north,
-        flag=RandomizationFlag.BUILDINGS | RandomizationFlag.IS_ONE_WAY,
+        flag=RandomizationFlag.BUILDINGS | RandomizationFlag.IS_ONE_WAY | GroupFlag.DOOR | GroupFlag.IN_TO_OUT,
     ),
     ConnectionData(Entrance.climb_to_volcano_10, Region.volcano_floor_10),
     ConnectionData(


### PR DESCRIPTION
When Decoupled and Same Type were on the entrance wouldn't generate correctly, as the flags weren't set.