### PR TITLE
Add Deferred Entrances support for Universal Tracker

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -663,7 +663,6 @@ class StardewValleyWorld(World):
             new_bits = new_bits >> 1
             if this_iter:
                 entrance_cache_invalid = True
-                print(f"new bit {index}, entrance {self.entrance_data_map[index]}")
 
                 entr, exit = self.entrance_data_map[index]
                 target = exit.connected_region

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -456,6 +456,7 @@ class StardewValleyWorld(World):
         set_rules(self)
 
     def connect_entrances(self) -> None:
+        self.entrance_cache_invalid = True
         is_chaos = self.options.entrance_randomization_behavior.is_chaos()
         # when the cutscene-relevant entrances aren't randomized, connect them manually
         if self.options.entrance_randomization.value < EntranceRandomization.option_overworld or is_chaos:
@@ -635,6 +636,7 @@ class StardewValleyWorld(World):
 
     # UT support
     found_entrances_datastorage_key = "found_entrances"
+    entrance_cache_invalid: bool
     previous_explanation: RuleExplanation | None = None
 
     def explain_rule(self, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
@@ -658,6 +660,7 @@ class StardewValleyWorld(World):
             this_iter = new_bits & 0b1
             new_bits = new_bits >> 1
             if this_iter:
+                entrance_cache_invalid = True
                 print(f"new bit {index}, entrance {self.entrance_data_map[index]}")
 
             index += 1

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -635,22 +635,24 @@ class StardewValleyWorld(World):
             player_state[Event.received_progression_percent] = (received_progression_count * 100 // self.total_progression_items)
 
     # UT support
-    found_entrances_datastorage_key = "found_entrances"
+    found_entrances_datastorage_key = "Slot:{player}:found_entrances"
     entrance_cache_invalid: bool
     previous_explanation: RuleExplanation | None = None
 
     def explain_rule(self, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
         from .client import cmd_explain
+
         return cmd_explain(self, target_name, state)
 
     def explain_more(self, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
         from .client import cmd_more
+
         return cmd_more(self, target_name, state)
 
     def reconnect_found_entrances(self, key: str, value: Any) -> None:
         if value is None or key is None or self.multiworld.enforce_deferred_connections == "off":
             return
-        if key != self.found_entrances_datastorage_key:
+        if key != self.found_entrances_datastorage_key.replace("{player}", str(self.player)):
             return
 
         new_bits: int = value & (~self.visited_entrances)
@@ -662,5 +664,10 @@ class StardewValleyWorld(World):
             if this_iter:
                 entrance_cache_invalid = True
                 print(f"new bit {index}, entrance {self.entrance_data_map[index]}")
+
+                entr, exit = self.entrance_data_map[index]
+                target = exit.connected_region
+                entr.connect(target)
+                target.entrances.remove(exit)
 
             index += 1

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -12,7 +12,6 @@ from NetUtils import JSONMessagePart
 from Options import PerGameCommonOptions
 from worlds.AutoWorld import WebWorld, World
 from worlds.LauncherComponents import Component, Type, components, icon_paths
-from worlds.stardew_valley.regions.model import reverse_connection_name
 from .bundles.bundle_room import BundleRoom
 from .bundles.bundles import get_all_bundles, get_trash_bear_requests
 from .content import StardewContent, create_content
@@ -36,6 +35,7 @@ from .options.settings import StardewSettings
 from .options.worlds_group import apply_most_restrictive_options
 from .regions import create_regions, prepare_mod_data
 from .regions.entrance_rando import get_target_groups
+from .regions.model import reverse_connection_name
 from .rules import set_rules
 from .stardew_rule import HasProgressionPercent, StardewRule, True_
 from .strings.ap_names.ap_option_names import EntranceRandomizationBehaviorOptionName, StartWithoutOptionName
@@ -494,9 +494,17 @@ class StardewValleyWorld(World):
             )
             self.randomized_entrances = prepare_mod_data(placement, self.forced_entrances)
         elif not is_chaos:
+
             # randomized_entrances were in the slot_data, connecting them as entered
             entrances = {entrance.name: entrance for region in self.get_regions() for entrance in region.entrances if entrance.parent_region is None}
             exits = {exit_.name: exit_ for region in self.get_regions() for exit_ in region.exits if exit_.connected_region is None}
+
+            is_ut = getattr(self.multiworld, "generation_is_fake", False)
+            if is_ut and self.multiworld.enforce_deferred_connections in ("on", "default"):
+                from .client import setup_ut_deferred_entrances
+                self.entrance_data_map = setup_ut_deferred_entrances(self.randomized_entrances, entrances, exits)
+                self.visited_entrances = 0
+                return
 
             for original, random in self.randomized_entrances.items():
                 rev_random = reverse_connection_name(random) or random
@@ -625,6 +633,8 @@ class StardewValleyWorld(World):
             # We can't update the percentage if we don't know the total progression items, can't divide by 0.
             player_state[Event.received_progression_percent] = (received_progression_count * 100 // self.total_progression_items)
 
+    # UT support
+    found_entrances_datastorage_key = "found_entrances"
     previous_explanation: RuleExplanation | None = None
 
     def explain_rule(self, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
@@ -634,3 +644,20 @@ class StardewValleyWorld(World):
     def explain_more(self, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
         from .client import cmd_more
         return cmd_more(self, target_name, state)
+
+    def reconnect_found_entrances(self, key: str, value: Any) -> None:
+        if value is None or key is None or self.multiworld.enforce_deferred_connections == "off":
+            return
+        if key != self.found_entrances_datastorage_key:
+            return
+
+        new_bits: int = value & (~self.visited_entrances)
+        index = 0
+        self.visited_entrances |= new_bits
+        while new_bits != 0:
+            this_iter = new_bits & 0b1
+            new_bits = new_bits >> 1
+            if this_iter:
+                print(f"new bit {index}, entrance {self.entrance_data_map[index]}")
+
+            index += 1

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -1,3 +1,4 @@
+from NetUtils import JSONMessagePart
 import logging
 import math
 import typing
@@ -38,6 +39,7 @@ from .regions.entrance_rando import get_target_groups
 from .rules import set_rules
 from .stardew_rule import HasProgressionPercent, StardewRule, True_
 from .strings.ap_names.ap_option_names import EntranceRandomizationBehaviorOptionName, StartWithoutOptionName
+from .stardew_rule.rule_explain import RuleExplanation
 from .strings.ap_names.ap_weapon_names import APWeapon
 from .strings.ap_names.event_names import Event
 from .strings.entrance_names import Entrance as EntranceNames
@@ -94,26 +96,6 @@ class StardewWebWorld(WebWorld):
     )
 
     tutorials = [setup_en, setup_fr]
-
-
-if TRACKER_ENABLED:
-    import os
-
-    from .. import user_folder
-
-    # Best effort to detect if universal tracker is installed
-    if any("tracker.apworld" in f.name for f in os.scandir(user_folder)):
-        def launch_client(*args):
-            from worlds.LauncherComponents import launch
-
-            from .client import launch as client_main
-
-            launch(client_main, name="Stardew Valley Tracker", args=args)
-
-
-        components.append(Component("Stardew Valley Tracker", func=launch_client, component_type=Type.CLIENT, icon="stardew"))
-
-        icon_paths["stardew"] = f"ap:{__name__}/stardew.png"
 
 
 class StardewValleyWorld(World):
@@ -642,3 +624,13 @@ class StardewValleyWorld(World):
             # Total progression items is not set until all items are created, but collect will be called during the item creation when an item is precollected.
             # We can't update the percentage if we don't know the total progression items, can't divide by 0.
             player_state[Event.received_progression_percent] = (received_progression_count * 100 // self.total_progression_items)
+
+    previous_explanation: RuleExplanation | None = None
+
+    def explain_rule(self, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
+        from .client import cmd_explain
+        return cmd_explain(self, target_name, state)
+
+    def explain_more(self, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
+        from .client import cmd_more
+        return cmd_more(self, target_name, state)

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -1,4 +1,3 @@
-from NetUtils import JSONMessagePart
 import logging
 import math
 import typing
@@ -9,6 +8,7 @@ from typing import Any, ClassVar, Dict, List, Optional, TextIO
 
 import entrance_rando
 from BaseClasses import CollectionState, Entrance, Item, ItemClassification, Location, MultiWorld, Region, Tutorial
+from NetUtils import JSONMessagePart
 from Options import PerGameCommonOptions
 from worlds.AutoWorld import WebWorld, World
 from worlds.LauncherComponents import Component, Type, components, icon_paths

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -15,27 +15,6 @@ try:
 
     tracker_loaded = True
 except ImportError as e:
-    logger.error(e)
-    from CommonClient import CommonContext, ClientCommandProcessor
-
-    TrackerCore = object
-
-
-    class TrackerGameContextMixin:
-        """Expecting the TrackerGameContext to have these methods."""
-        tracker_core: TrackerCore
-
-        def make_gui(self, manager):
-            ...
-
-        def run_generator(self):
-            ...
-
-
-    class TrackerGameContext(CommonContext, TrackerGameContextMixin):
-        pass
-
-
     tracker_loaded = False
     UT_VERSION = "Not found"
 

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -9,15 +9,6 @@ from . import StardewValleyWorld
 from .logic.logic import StardewLogic
 from .stardew_rule.rule_explain import explain, ExplainMode, RuleExplanation
 
-try:
-    from worlds.tracker.TrackerClient import TrackerGameContext, TrackerCommandProcessor as ClientCommandProcessor, UT_VERSION  # noqa
-    from worlds.tracker.TrackerCore import TrackerCore
-
-    tracker_loaded = True
-except ImportError as e:
-    tracker_loaded = False
-    UT_VERSION = "Not found"
-
 
 def cmd_explain(world: StardewValleyWorld, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
     logic = world.logic

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 import re
-# webserver imports
-import urllib.parse
-from collections.abc import Iterable
 
 import Utils
 from BaseClasses import CollectionState, Location
-from CommonClient import logger, get_base_parser, gui_enabled, server_loop
-from MultiServer import mark_raw
 from NetUtils import JSONMessagePart
-from kvui import CommandPromptTextInput
 from . import StardewValleyWorld
 from .logic.logic import StardewLogic
 from .stardew_rule.rule_explain import explain, ExplainMode, RuleExplanation
@@ -47,160 +40,41 @@ except ImportError as e:
     UT_VERSION = "Not found"
 
 
-class StardewCommandProcessor(ClientCommandProcessor):
-    ctx: StardewClientContext
+def cmd_explain(world: StardewValleyWorld, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
+    logic = world.logic
 
-    @mark_raw
-    def _cmd_explain(self, location: str = ""):
-        """Explain the logic behind a location."""
-        logic = self.ctx.logic
-        if logic is None:
-            return
+    if target_name.startswith("missing "):
+        expected = True
+        target_name = target_name[len("missing "):]
+    elif target_name.startswith("how "):
+        expected = False
+        target_name = target_name[len("how "):]
+    else:
+        expected = None
 
-        try:
-            rule = logic.region.can_reach_location(location)
-            expl = explain(rule, self.ctx.current_state, expected=None, mode=ExplainMode.CLIENT)
-        except KeyError:
-
-            result, usable, response = Utils.get_intended_text(location, [loc.name for loc in self.ctx.all_locations])
-            if usable:
-                rule = logic.region.can_reach_location(result)
-                expl = explain(rule, self.ctx.current_state, expected=None, mode=ExplainMode.CLIENT)
-            else:
-                self.ctx.ui.last_autofillable_command = "/explain"
-                self.output(response)
-                return
-
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
-
-    @mark_raw
-    def _cmd_explain_item(self, item: str = ""):
-        """Explain the logic behind a game item."""
-        logic = self.ctx.logic
-        if logic is None:
-            return
-
-        result, usable, response = Utils.get_intended_text(item, logic.registry.item_rules.keys())
-        if usable:
-            rule = logic.has(result)
-            expl = explain(rule, self.ctx.current_state, expected=None, mode=ExplainMode.CLIENT)
-        else:
-            self.ctx.ui.last_autofillable_command = "/explain_item"
-            self.output(response)
-            return
-
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
-
-    @mark_raw
-    def _cmd_explain_missing(self, location: str = ""):
-        """Explain what is missing for a location to be in logic. It explains the logic behind a location, while skipping the rules that are already satisfied."""
-        self.__explain("/explain_missing", location, expected=True)
-
-    @mark_raw
-    def _cmd_explain_how(self, location: str = ""):
-        """Explain how a location is in logic. It explains the logic behind the location, while skipping the rules that are not satisfied."""
-        self.__explain("/explain_how", location, expected=False)
-
-    def __explain(self, command: str, location: str, expected: bool | None = None):
-        logic = self.ctx.logic
-        if logic is None:
-            return
-
-        try:
-            rule = logic.region.can_reach_location(location)
-            expl = explain(rule, self.ctx.current_state, expected=expected, mode=ExplainMode.CLIENT)
-        except KeyError:
-
-            result, usable, response = Utils.get_intended_text(location, [loc.name for loc in self.ctx.all_locations])
-            if usable:
-                rule = logic.region.can_reach_location(result)
-                expl = explain(rule, self.ctx.current_state, expected=expected, mode=ExplainMode.CLIENT)
-            else:
-                self.ctx.ui.last_autofillable_command = command
-                self.output(response)
-                return
-
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
-
-    @mark_raw
-    def _cmd_more(self, index: str = ""):
-        """Will tell you what's missing to consider a location in logic."""
-        if self.ctx.previous_explanation is None:
-            self.output("No previous explanation found.")
-            return
-
-        try:
-            expl = self.ctx.previous_explanation.more(int(index))
-        except (ValueError, IndexError):
-            self.output("Which previous rule do you want to explained?")
-            self.ctx.ui.last_autofillable_command = "/more"
-            for i, rule in enumerate(self.ctx.previous_explanation.more_explanations):
-                # TODO handle autofillable commands
-                self.output(f"/more {i} -> {str(rule)})")
-            return
-
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
-
-    if not tracker_loaded:
-        del _cmd_explain
-        del _cmd_explain_missing
+    result, usable, response = Utils.get_intended_text(target_name, world.get_all_location_names())
+    if usable:
+        rule = logic.region.can_reach_location(result)
+        expl = explain(rule, state, expected=expected, mode=ExplainMode.CLIENT)
+        world.previous_explanation = expl
+        return parse_explanation(expl)
+    else:
+        return [{"type": "color", "color": "salmon", "text": response}]
 
 
-class StardewClientContext(TrackerGameContext):
-    game = "Stardew Valley"
-    command_processor = StardewCommandProcessor
-    previous_explanation: RuleExplanation | None = None
+def cmd_more(world: StardewValleyWorld, index: str, state: CollectionState) -> list[JSONMessagePart]:
+    logic = world.logic
 
-    def make_gui(self):
-        ui = super().make_gui()  # before the kivy imports so kvui gets loaded first
+    if world.previous_explanation is None:
+        return [{"type": "color", "color": "salmon", "text": "No previous explanation found"}]
 
-        class StardewManager(ui):
-            base_title = f"Stardew Valley Tracker with UT {UT_VERSION} for AP version"  # core appends ap version so this works
-            ctx: StardewClientContext
+    try:
+        expl = world.previous_explanation.more(int(index))
+    except (ValueError, IndexError):
+        return [{"type": "text", "text": "Which previous rule do you want to be explained?"}]
 
-            def build(self):
-                container = super().build()
-                if not tracker_loaded:
-                    logger.info("To enable the tracker page, install Universal Tracker.")
-
-                # Until self.ctx.ui.last_autofillable_command allows for / commands, this is needed to remove the "!" before the /commands when using intended text autofill.
-                def on_text_remove_hardcoded_exclamation_mark_garbage(textinput: CommandPromptTextInput, text: str) -> None:
-                    if text.startswith("!/"):
-                        textinput.text = text[1:]
-
-                self.textinput.bind(text=on_text_remove_hardcoded_exclamation_mark_garbage)
-
-                return container
-
-        return StardewManager
-
-    @property
-    def logic(self) -> StardewLogic | None:
-        if self.tracker_core.get_current_world() is None:
-            logger.warning("Internal logic was not able to load, check your yamls and relaunch.")
-            return None
-
-        if self.game != "Stardew Valley":
-            logger.warning(f"Please connect to a slot with explainable logic (not {self.game}).")
-            return None
-
-        return self.tracker_core.get_current_world().logic
-
-    @property
-    def current_state(self) -> CollectionState:
-        return self.tracker_core.updateTracker().state
-
-    @property
-    def world(self) -> StardewValleyWorld:
-        return self.tracker_core.get_current_world()
-
-    @property
-    def all_locations(self) -> Iterable[Location]:
-        return self.tracker_core.multiworld.get_locations(self.tracker_core.player_id)
+    world.previous_explanation = expl
+    return parse_explanation(expl)
 
 
 def parse_explanation(explanation: RuleExplanation) -> list[JSONMessagePart]:
@@ -246,39 +120,3 @@ def parse_explanation(explanation: RuleExplanation) -> list[JSONMessagePart]:
             messages.append({"text": s, "type": "text"})
 
     return messages
-
-
-async def main(args):
-    ctx = StardewClientContext(args.connect, args.password)
-
-    ctx.auth = args.name
-    ctx.server_task = asyncio.create_task(server_loop(ctx), name="server loop")
-
-    if tracker_loaded:
-        ctx.run_generator()
-    else:
-        logger.warning("Could not find Universal Tracker.")
-
-    if gui_enabled:
-        ctx.run_gui()
-    ctx.run_cli()
-
-    await ctx.exit_event.wait()
-    await ctx.shutdown()
-
-
-def launch(*args):
-    parser = get_base_parser(description="Gameless Archipelago Client, for text interfacing.")
-    parser.add_argument('--name', default=None, help="Slot Name to connect as.")
-    parser.add_argument("url", nargs="?", help="Archipelago connection url")
-    args = parser.parse_args(args)
-
-    if args.url:
-        url = urllib.parse.urlparse(args.url)
-        args.connect = url.netloc
-        if url.username:
-            args.name = urllib.parse.unquote(url.username)
-        if url.password:
-            args.password = urllib.parse.unquote(url.password)
-
-    asyncio.run(main(args))

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -43,6 +43,12 @@ except ImportError as e:
 def cmd_explain(world: StardewValleyWorld, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
     logic = world.logic
 
+    if target_name.startswith("item "):
+        is_item_explain = True
+        target_name = target_name[len("item "):]
+    else:
+        is_item_explain = False
+
     if target_name.startswith("missing "):
         expected = True
         target_name = target_name[len("missing "):]
@@ -52,9 +58,13 @@ def cmd_explain(world: StardewValleyWorld, target_name: str, state: CollectionSt
     else:
         expected = None
 
-    result, usable, response = Utils.get_intended_text(target_name, world.get_all_location_names())
+    possible_answers = logic.registry.item_rules.keys() if is_item_explain else world.get_all_location_names()
+    result, usable, response = Utils.get_intended_text(target_name, possible_answers)
     if usable:
-        rule = logic.region.can_reach_location(result)
+        if is_item_explain:
+            rule = logic.has(result)
+        else:
+            rule = logic.region.can_reach_location(result)
         expl = explain(rule, state, expected=expected, mode=ExplainMode.CLIENT)
         world.previous_explanation = expl
         return parse_explanation(expl)

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -72,6 +72,8 @@ def parse_explanation(explanation: RuleExplanation) -> list[JSONMessagePart]:
             messages.append({"type": "color", "color": "green", "text": s})
         elif s == "False":
             messages.append({"type": "color", "color": "salmon", "text": s})
+        elif s == "Undiscovered":
+            messages.append({"type": "color", "color": "salmon", "text": s})
         elif s.startswith("Reach Location "):
             messages.append({"type": "text", "text": "Reach Location "})
             messages.append({"type": "location_name", "text": s[15:]})
@@ -115,4 +117,6 @@ def setup_ut_deferred_entrances(randomized_entrances: dict[str, str], entrances:
 
         entrance_data.append((ex, entr))
 
+    for i, ed in enumerate(entrance_data):
+        print(f"{i}: {ed}")
     return entrance_data

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import re
 
 import Utils
-from BaseClasses import CollectionState, Location
+from BaseClasses import CollectionState, Location, Entrance
 from NetUtils import JSONMessagePart
 from . import StardewValleyWorld
 from .logic.logic import StardewLogic
+from .regions.entrance_rando import reverse_connection_name
 from .stardew_rule.rule_explain import explain, ExplainMode, RuleExplanation
 
 
@@ -100,3 +101,18 @@ def parse_explanation(explanation: RuleExplanation) -> list[JSONMessagePart]:
             messages.append({"text": s, "type": "text"})
 
     return messages
+
+
+def setup_ut_deferred_entrances(randomized_entrances: dict[str, str], entrances: dict[str, Entrance], exits: dict[str, Entrance]):
+    sorted_entrance_names = sorted(randomized_entrances.items())
+
+    entrance_data = []
+
+    for original, randomized in sorted_entrance_names:
+        rev_random = reverse_connection_name(randomized) or randomized
+        ex = exits[original]
+        entr = entrances[rev_random]
+
+        entrance_data.append((ex, entr))
+
+    return entrance_data

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -117,6 +117,4 @@ def setup_ut_deferred_entrances(randomized_entrances: dict[str, str], entrances:
 
         entrance_data.append((ex, entr))
 
-    for i, ed in enumerate(entrance_data):
-        print(f"{i}: {ed}")
     return entrance_data

--- a/worlds/stardew_valley/stardew_rule/literal.py
+++ b/worlds/stardew_valley/stardew_rule/literal.py
@@ -50,7 +50,28 @@ class False_(LiteralStardewRule):  # noqa
         return self
 
 
+class Undiscovered_(LiteralStardewRule):
+    value = False
+
+    def __new__(cls, _cache=[]):  # noqa
+        # Only one single instance will be ever created.
+        if not _cache:
+            _cache.append(super(Undiscovered_, cls).__new__(cls))
+        return _cache[0]
+
+    def __or__(self, other) -> StardewRule:
+        return other
+
+    def __and__(self, other) -> StardewRule:
+        return self
+
+    def __repr__(self):
+        return str("Undiscovered")
+
+
 false_ = False_()
 true_ = True_()
+undiscovered_ = Undiscovered_()
 assert false_
 assert true_
+assert undiscovered_

--- a/worlds/stardew_valley/stardew_rule/rule_explain.py
+++ b/worlds/stardew_valley/stardew_rule/rule_explain.py
@@ -122,7 +122,7 @@ class MoreExplanation:
             depth *= 2
 
         line = "  " * depth + f"{str(self.rule)} -> {self.result}"
-        line += f" [use `/more {self.more_index}` to explain]"
+        line += f" [use `/explain_more {self.more_index}` to explain]"
 
         return line
 

--- a/worlds/stardew_valley/stardew_rule/rule_explain.py
+++ b/worlds/stardew_valley/stardew_rule/rule_explain.py
@@ -9,7 +9,7 @@ from typing import Iterable, List, Optional, Set, Tuple
 from BaseClasses import CollectionState, MultiWorld, Region
 from worlds.generic.Rules import CollectionRule
 from . import (AggregatingStardewRule, Count, Has, Reach, Received,
-               StardewRule, TotalReceived, true_, false_)
+               StardewRule, TotalReceived, true_, undiscovered_)
 
 
 class ExplainMode(enum.Enum):
@@ -480,7 +480,7 @@ def _(
 
         for entrance in spot.entrances:
             if entrance.parent_region is None:
-                access_rules.append(false_)
+                access_rules.append(undiscovered_)
                 continue
             assert isinstance(
                 entrance.parent_region, Region

--- a/worlds/stardew_valley/stardew_rule/rule_explain.py
+++ b/worlds/stardew_valley/stardew_rule/rule_explain.py
@@ -9,7 +9,7 @@ from typing import Iterable, List, Optional, Set, Tuple
 from BaseClasses import CollectionState, MultiWorld, Region
 from worlds.generic.Rules import CollectionRule
 from . import (AggregatingStardewRule, Count, Has, Reach, Received,
-               StardewRule, TotalReceived, true_)
+               StardewRule, TotalReceived, true_, false_)
 
 
 class ExplainMode(enum.Enum):
@@ -34,7 +34,8 @@ def access_graph(multiworld: MultiWorld, player: int):
         checking_region = to_check.popleft()
 
         for exit in checking_region.exits:
-            assert exit.connected_region is not None, f"All exits should be connected, error at {exit}"
+            if exit.connected_region is None:
+                continue
             neighbor = exit.connected_region
 
             # Always record the directed edge
@@ -469,14 +470,18 @@ def _(
         spot = state.multiworld.get_region(rule.spot, rule.player)
 
         global region_graph
-        if region_graph is None:
+        if region_graph is None or state.multiworld.worlds[rule.player].entrance_cache_invalid:
             valid_parent_cache.clear()
             region_graph = access_graph(state.multiworld, rule.player)
+            state.multiworld.worlds[rule.player].entrance_cache_invalid = False
 
         valid_parent_regions = set(valid_parents_to_origin(spot.name))
         valid_parent_regions -= blocked_regions
 
         for entrance in spot.entrances:
+            if entrance.parent_region is None:
+                access_rules.append(false_)
+                continue
             assert isinstance(
                 entrance.parent_region, Region
             ), f"Entrance to region should have a parent region, problem is {entrance.name}"


### PR DESCRIPTION
Add deferred entrances for universal tracker.

Can not be rebased to 7.x.x since it uses parts of the 8.x.x entrance randomization to work correctly.

<img width="890" height="1076" alt="image" src="https://github.com/user-attachments/assets/5f4982e4-320c-43e7-ad5c-e8b86aa30bba" />
