### PR TITLE
the check if key was the same is unnecessary and actually broke stuff

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -653,8 +653,6 @@ class StardewValleyWorld(World):
     def reconnect_found_entrances(self, key: str, value: Any) -> None:
         if value is None or key is None or self.multiworld.enforce_deferred_connections == "off":
             return
-        if key != self.found_entrances_datastorage_key.replace("{player}", str(self.player)):
-            return
 
         new_bits: int = value & (~self.visited_entrances)
         index = 0


### PR DESCRIPTION
So apparently `reconnect_found_entrances` would only be called on the current slot's key anyways. And during the re-gen of UT only 1 world would generate so `self.player` would always be 1.

This is why deferred entrances worked when testing on a single slot archipelago but broke in my multiworld.